### PR TITLE
chromium: fix gnome dependency

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -1,4 +1,5 @@
 { newScope, stdenv, makeWrapper, makeDesktopItem, ed, overrideCC, pkgs
+, gnome
 
 # package customization
 , channel ? "stable"


### PR DESCRIPTION
This fixes the evaluation. Running a build off of it, now.
